### PR TITLE
Trying to implement onErrorResumeNext

### DIFF
--- a/monifu/shared/src/main/scala/monifu/reactive/Observable.scala
+++ b/monifu/shared/src/main/scala/monifu/reactive/Observable.scala
@@ -531,6 +531,14 @@ trait Observable[+T] { self =>
     operators.scan(self, initial)(op)
 
   /**
+   * When stream is interrupted with an error, resumes it with given Observable.
+   *
+   * @param resumeSequence the Observable that will emit elements if the current has an error
+   */
+  def onErrorResumeNext[U >: T](resumeSequence: Observable[U]): Observable[U] =
+    operators.onError.onErrorResumeNext(self, resumeSequence)
+
+  /**
    * Executes the given callback when the stream has ended,
    * but before the complete event is emitted.
    *

--- a/monifu/shared/src/main/scala/monifu/reactive/operators/onError.scala
+++ b/monifu/shared/src/main/scala/monifu/reactive/operators/onError.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2015 Alexandru Nedelcu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monifu.reactive.operators
+
+import monifu.reactive.{Ack, Observer, Observable}
+import scala.concurrent.Future
+
+object onError {
+  /**
+   * Implementation for [[Observable.onErrorResumeNext]]
+   */
+  def onErrorResumeNext[T](source: Observable[T], resumeSequence: Observable[T]): Observable[T] = {
+    Observable.create { subscriber =>
+      implicit val s = subscriber.scheduler
+      val observer = subscriber.observer
+
+      source.unsafeSubscribe(new Observer[T] {
+        override def onNext(elem: T): Future[Ack] = observer.onNext(elem)
+
+        override def onError(ex: Throwable): Unit = resumeSequence.unsafeSubscribe(observer)
+
+        override def onComplete(): Unit = observer.onComplete()
+      })
+    }
+  }
+}

--- a/monifu/shared/src/test/scala/monifu/reactive/operators/OnErrorResumeNextSuite.scala
+++ b/monifu/shared/src/test/scala/monifu/reactive/operators/OnErrorResumeNextSuite.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2014-2015 Alexandru Nedelcu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monifu.reactive.operators
+
+import monifu.reactive.{DummyException, Observable}
+import scala.concurrent.duration.Duration.Zero
+
+object OnErrorResumeNextSuite extends BaseOperatorSuite {
+  override def observable(sourceCount: Int) = Some {
+    val (mid, rest) = divideCount(sourceCount)
+    val ex = new DummyException("expected")
+    val o1 = createObservableEndingInError(Observable.range(0, mid), ex)
+    val o2 = Observable.range(0, rest)
+
+    val o = o1.onErrorResumeNext(o2)
+
+    Sample(o, count(sourceCount), sum(sourceCount), Zero, Zero)
+  }
+
+  override def observableInError(sourceCount: Int, ex: Throwable) = Some {
+    val (mid, rest) = divideCount(sourceCount)
+    val ex1 = new DummyException("expected")
+    val o1 = createObservableEndingInError(Observable.range(0, mid), ex1)
+    val o2 = createObservableEndingInError(Observable.range(0, rest), ex)
+
+    val o = o1.onErrorResumeNext(o2)
+
+    Sample(o, count(sourceCount), sum(sourceCount), Zero, Zero)
+  }
+
+  def count(sourceCount: Int) = sourceCount
+  def sum(sourceCount: Int) = sourceCount * (sourceCount - 1) / 2
+
+  private def divideCount(sourceCount: Int): (Int, Int) = {
+    val mid = 1
+    val rest = sourceCount - mid
+    (mid, rest)
+  }
+
+  override def brokenUserCodeObservable(sourceCount: Int, ex: Throwable): Option[OnErrorResumeNextSuite.Sample] = None
+}


### PR DESCRIPTION
Implementing #39 onErrorResumeNext

Creating an initial PR to check what I am doing wrong. In the hope that it is not more work to help me then to actually implement it.

The tests are failing with a difference between expected and received emits. I have tried spliting the count with `divideCount` at the middle, at the end (with `sourceCount - 1`) and as it is now at the start. None of them seem to clarify as the error is by a larger amount then just `1`.